### PR TITLE
Require PHP >7.0 (fixes and cleanup)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 vendor/
+.idea/

--- a/composer.json
+++ b/composer.json
@@ -14,5 +14,8 @@
             "email": "polarnix@pm.me"
         }
     ],
-    "require": {}
+    "require": {
+        "php": ">7.0",
+        "ext-dom": "*"
+    }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,21 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "428e323fa5c73818ac852cc600cfe722",
+    "packages": [],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {
+        "php": ">7.0",
+        "ext-dom": "*"
+    },
+    "platform-dev": [],
+    "plugin-api-version": "2.3.0"
+}

--- a/index.php
+++ b/index.php
@@ -24,4 +24,12 @@ $form->field()
      ->style('border border-blue-100')
      ->value('polarnix');
 
-$form->render();
+$form->field()
+    ->type('submit')
+    ->value('submit');
+
+try {
+    $form->render();
+} catch (DOMException $e) {
+    echo "Failed to render form: $e";
+}

--- a/src/Field.php
+++ b/src/Field.php
@@ -19,22 +19,22 @@ class Field {
         $this->value = isset($attr['value']) ? $attr['value'] : '';
     }
 
-    public function name($name): object {
+    public function name($name): self {
         $this->name = $name;
         return $this;
     }
 
-    public function type($type): object {
+    public function type($type): self {
         $this->type = $type;
         return $this;
     }
 
-    public function style($style): object {
+    public function style($style): self {
         $this->style = $style;
         return $this;
     }
 
-    public function value($value): object {
+    public function value($value): self {
         $this->value = $value;
         return $this;
     }

--- a/src/Field.php
+++ b/src/Field.php
@@ -13,10 +13,10 @@ class Field {
     private $value;
 
     public function __construct(array $attr = []) {
-        $this->name = isset($attr['name']) ? $attr['name'] : '';
-        $this->type = isset($attr['type']) ? $attr['type'] : 'text';
-        $this->style = isset($attr['class']) ? $attr['class'] : '';
-        $this->value = isset($attr['value']) ? $attr['value'] : '';
+        $this->name = $attr['name'] ?? '';
+        $this->type = $attr['type'] ?? 'text';
+        $this->style = $attr['class'] ?? '';
+        $this->value = $attr['value'] ?? '';
     }
 
     public function name($name): self {

--- a/src/Field.php
+++ b/src/Field.php
@@ -5,11 +5,39 @@ namespace Formify;
 use DOMDocument;
 
 class Field {
+    /**
+     * The name that will be used in HTML to specify this field.
+     *
+     * @var string
+     */
     private $name;
+
+    /**
+     * The type of the field, e.g. text or checkbox.
+     *
+     * @var string
+     */
     private $type;
+
+    /**
+     * The string value that will be assigned to the field's `class` attribute.
+     *
+     * @var string
+     */
     private $style;
+
+    /**
+     * The string value that will be assigned to the field's `value` attribute.
+     *
+     * @var string
+     */
     private $value;
 
+    /**
+     * Construct a new Field.
+     *
+     * @param array<string, string> $attr
+     */
     public function __construct(array $attr = []) {
         $this->name = $attr['name'] ?? '';
         $this->type = $attr['type'] ?? 'text';
@@ -17,26 +45,56 @@ class Field {
         $this->value = $attr['value'] ?? '';
     }
 
+    /**
+     * Alter the name attribute.
+     *
+     * @param string $name
+     * @return $this
+     */
     public function name($name): self {
         $this->name = $name;
         return $this;
     }
 
+    /**
+     * Alter the type attribute.
+     *
+     * @param string $type
+     * @return $this
+     */
     public function type($type): self {
         $this->type = $type;
         return $this;
     }
 
+    /**
+     * Alter the class attribute.
+     *
+     * @param string $style
+     * @return $this
+     */
     public function style($style): self {
         $this->style = $style;
         return $this;
     }
 
+    /**
+     * Alter the value attribute.
+     *
+     * @param string $value
+     * @return $this
+     */
     public function value($value): self {
         $this->value = $value;
         return $this;
     }
 
+    /**
+     * Compile the Field into an element.
+     *
+     * @return mixed
+     * @throws \DOMException
+     */
     public function render() {
         $doc = new DOMDocument();
         $input_elm = $doc->createElement('input');

--- a/src/Field.php
+++ b/src/Field.php
@@ -3,8 +3,6 @@
 namespace Formify;
 
 use DOMDocument;
-use DOMElement;
-use DOMEntity;
 
 class Field {
     private $name;

--- a/src/Form.php
+++ b/src/Form.php
@@ -13,9 +13,9 @@ class Form {
     private $fields;
 
     public function __construct(array $config = []) {
-        $this->action = isset($config['action']) ? $config['action'] : '';
+        $this->action = $config['action'] ?? '';
         $this->method = isset($config['method']) ? strtoupper($config['method']) : 'POST';
-        $this->enctype = isset($config['enctype']) ? $config['enctype'] : 'multipart/form-data';
+        $this->enctype = $config['enctype'] ?? 'multipart/form-data';
         $this->fields = [];
     }
 

--- a/src/Form.php
+++ b/src/Form.php
@@ -5,11 +5,39 @@ namespace Formify;
 use DOMDocument;
 
 class Form {
+    /**
+     * The PHP file (action) this form should go to.
+     *
+     * @var string
+     */
     private $action;
+
+    /**
+     * The HTTP method the form should use to reach the action.
+     *
+     * @var string
+     */
     private $method;
+
+    /**
+     * The type of encoding the form data should be encoded with.
+     *
+     * @var string
+     */
     private $enctype;
+
+    /**
+     * The fields that are in this form.
+     *
+     * @var array<int, Field>
+     */
     private $fields;
 
+    /**
+     * Construct a new Form.
+     *
+     * @param non-empty-array<string, string> $config
+     */
     public function __construct(array $config = []) {
         $this->action = $config['action'] ?? '';
         $this->method = isset($config['method']) ? strtoupper($config['method']) : 'POST';
@@ -17,12 +45,24 @@ class Form {
         $this->fields = [];
     }
 
+    /**
+     * Construct a new `Field` and return it.
+     *
+     * @see Field
+     * @return Field
+     */
     public function field(): Field {
         $field = new Field;
         $this->fields[] = $field;
         return $field;
     }
 
+    /**
+     * Renders the form to the view, so it can be sent to the browser.
+     *
+     * @return void
+     * @throws \DOMException
+     */
     public function render() {
         $doc = new DOMDocument();
         $html = $doc->createElement('form');

--- a/src/Form.php
+++ b/src/Form.php
@@ -3,8 +3,6 @@
 namespace Formify;
 
 use DOMDocument;
-use DOMElement;
-use Formify\Field;
 
 class Form {
     private $action;


### PR DESCRIPTION
## Fixes

I've changed the required PHP version to >7.0 because of:
- PHP's `strict_types` declaration requiring such
- PHP return types having been introduced in 7.0
---
I've also required the `ext-dom` extension because it is used in the project.

And in the index.php example handle potential exception on the form's render method.

## Refactoring
I've simplified the usage of ternary operators by removing unnecessary steps they had.

## Cleanup
Removed unnecessary imports

## Doc
Added basic documentation.